### PR TITLE
Implement pitch creation on climbing route creation

### DIFF
--- a/app/models/climbing_route.rb
+++ b/app/models/climbing_route.rb
@@ -34,6 +34,7 @@ class ClimbingRoute < ApplicationRecord
 
   scope :by_sector, -> (sector) { includes(crag: :sector).where(crags: { sector: sector }) }
 
+  after_create :create_single_pitch, if: -> { previously_new_record? }
   after_create :sanitize_grade_and_set_standardized_grade
   before_commit :sanitize_grade_and_set_standardized_grade, on: :update, if: -> { :will_save_change_to_grade? }
 
@@ -47,5 +48,15 @@ class ClimbingRoute < ApplicationRecord
 
   def grading_system
     country.grading_system
+  end
+
+  def create_single_pitch
+    pitches.create(
+      position: 1,
+      length: height,
+      pitch_grade: grade,
+      angle: angle,
+      bolts: 0 # TODO Figure where to get this data from
+    )
   end
 end

--- a/app/models/climbing_route.rb
+++ b/app/models/climbing_route.rb
@@ -34,7 +34,7 @@ class ClimbingRoute < ApplicationRecord
 
   scope :by_sector, -> (sector) { includes(crag: :sector).where(crags: { sector: sector }) }
 
-  after_create :create_single_pitch, if: -> { previously_new_record? }
+  after_create :create_single_pitch
   after_create :sanitize_grade_and_set_standardized_grade
   before_commit :sanitize_grade_and_set_standardized_grade, on: :update, if: -> { :will_save_change_to_grade? }
 

--- a/spec/models/climbing_route_spec.rb
+++ b/spec/models/climbing_route_spec.rb
@@ -14,18 +14,23 @@ RSpec.describe ClimbingRoute, type: :model do
     end
   end
 
-  describe '#pitch' do
-    before do
-      pitch = Pitch.new(
-        position: 2,
-        length: 20,
-        pitch_grade: instance.grade,
-        angle: 90,
-        bolts: 7
-      )
-      pitch.climbing_route = instance
-    end
+  describe '#create_single_pitch' do
+    context 'when creating a new single pitch climbing_route' do
+      let(:new_climbing_route) { build(:single_pitch_sport_climbing_route) }
 
+      it 'creates its first pitch', :aggregate_failures do
+        expect(new_climbing_route.pitch).to be_nil
+
+        new_climbing_route.save
+        pitch = new_climbing_route.pitch
+
+        expect(pitch).to be_a(Pitch)
+        expect(pitch.climbing_route).to be(new_climbing_route)
+      end
+    end
+  end
+
+  describe '#pitch' do
     it 'returns the first pitch of the climbing_route' do
       expect(instance.pitch).to eq(instance.pitches.first)
     end

--- a/spec/models/climbing_route_spec.rb
+++ b/spec/models/climbing_route_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe ClimbingRoute, type: :model do
         expect(pitch.climbing_route).to be(new_climbing_route)
       end
     end
+
+    context 'when updating a single pitch climbing_route' do
+      let(:pitch) { instance.pitch }
+
+      it 'does not create a new pitch', :aggregate_failures do
+        expect(pitch).not_to be_nil
+
+        instance.update!(name: 'Gossos: NO!')
+
+        expect(instance.pitches.count).to eq(1)
+        expect(pitch.id).to eq(instance.pitches.last.id)
+      end
+    end
   end
 
   describe '#pitch' do


### PR DESCRIPTION
## Why

On the creation of a `ClimbingRoute` instance, a first `Pitch` instance needs to be created.
We are focusing on single pitch routes at the moment.

## What

<!-- List of changes -->

* Added an `after_create` hook in the `ClimbingRoute` model, to trigger the new `#create_single_pitch` method
* Added 2 tests

## How to test

Run the rspec `spec/models/climbing_route_spec.rb`
